### PR TITLE
[s3/alb] Can parse line which includes hostname and certificate

### DIFF
--- a/node_modules/s3-log-parser.js
+++ b/node_modules/s3-log-parser.js
@@ -10,19 +10,19 @@ var parseLine = function(line) {
     if (quoted) {
       if (escaped) {
         escaped = false;
-      } else if (c == '\\') {
+      } else if (c === '\\') {
         escaped = true;
-      } else if (c == '"') {
+      } else if (c === '"') {
         quoted = false;
         tokens.push(line.substring(start, i));
         start = i + 1;
       }
-    } else if (c == " ") {
-      if (i != start) {
+    } else if (c === " ") {
+      if (i !== start) {
         tokens.push(line.substring(start, i));
       }
       start = i + 1;
-    } else if (i == start && c == '"') {
+    } else if (i === start && c === '"') {
       quoted = true;
       escaped = false;
       start = i + 1;
@@ -49,7 +49,7 @@ var handleELBTokens = function(tokens) {
     request_processing_time: parseFloat(tokens[4]),
     backend_processing_time: parseFloat(tokens[5]),
     response_processing_time: parseFloat(tokens[6]),
-    elb_status_code: tokens[7],
+    http_status: tokens[7],
     backend_status_code: tokens[8],
     received_bytes: parseFloat(tokens[9]),
     sent_bytes: parseFloat(tokens[10]),
@@ -63,34 +63,76 @@ var handleELBTokens = function(tokens) {
 };
 
 var handleALBTokens = function(tokens) {
+  var type = tokens[0];
+  var timestamp = tokens[1];
+  var alb = tokens[2];
+
   var client_address = tokens[3].split(":");
+  var client_ip = client_address[0];
+  var client_port = client_address[1];
+
   var target_address = tokens[4].split(":");
+  var target = target_address[0];
+  var target_port = target_address[1];
+
+  var request_processing_time = parseFloat(tokens[5]);
+  var target_processing_time = parseFloat(tokens[6]);
+  var response_processing_time = parseFloat(tokens[7]);
+  var http_status = tokens[8];
+  var target_status_code = tokens[9];
+  var received_bytes = parseFloat(tokens[10]);
+  var sent_bytes = parseFloat(tokens[11]);
+
   var request_info = tokens[12].split(" ");
+  var request_method = request_info[0];
   var request_url_components = request_info[1].split("?");
-  return {
-    type: tokens[0],
-    timestamp: tokens[1],
-    elb: tokens[2],
-    client_ip: client_address[0],
-    client_port: client_address[1],
-    target: target_address[0],
-    target_port: target_address[1] || "-",
-    request_processing_time: parseFloat(tokens[5]),
-    target_processing_time: parseFloat(tokens[6]),
-    response_processing_time: parseFloat(tokens[7]),
-    elb_status_code: tokens[8],
-    target_status_code: tokens[9],
-    received_bytes: parseFloat(tokens[10]),
-    sent_bytes: parseFloat(tokens[11]),
-    request_method: request_info[0],
-    request_url: request_url_components[0],
-    request_query_params: request_url_components[1] || "",
-    user_agent: tokens[13],
-    ssl_cipher: tokens[14],
-    ssl_protocol: tokens[15],
-    target_group_arn: tokens[16],
-    trace_id: tokens[17],
+  var request_url = request_url_components[0];
+  var request_query_params = request_url_components[1];
+
+  var user_agent = tokens[13];
+  var ssl_cipher = tokens[14];
+  var ssl_protocol = tokens[15];
+  var target_group_arn = tokens[16];
+  var trace_id = tokens[17];
+  var hostname = tokens.length > 18 && tokens[18];
+  var certificate_arn = tokens.length > 19 && tokens[19];
+  var data = {
+    type: type,
+    timestamp: timestamp,
+    alb: alb,
+    client_ip: client_ip,
+    client_port: client_port,
+    target: target,
+    // target_port: see below
+    request_processing_time: request_processing_time,
+    target_processing_time: target_processing_time,
+    response_processing_time: response_processing_time,
+    http_status: http_status,
+    target_status_code: target_status_code,
+    received_bytes: received_bytes,
+    sent_bytes: sent_bytes,
+    request_method: request_method,
+    request_url: request_url,
+    // request_query_params: see below
+    user_agent: user_agent,
+    ssl_cipher: ssl_cipher,
+    ssl_protocol: ssl_protocol,
+    target_group_arn: target_group_arn,
+    trace_id: trace_id,
   };
+  if (target_port) {
+    data.target_port = target_port;
+  }
+  if (request_query_params) {
+    data.request_query_params = request_query_params;
+  }
+  if (hostname) {
+    data.hostname = hostname;
+  }
+  if (certificate_arn) {
+    data.certificate_arn = certificate_arn;
+  }
+  return data;
 };
 
 var handleUnknownTokens = function(tokens) {
@@ -101,14 +143,13 @@ var handleUnknownTokens = function(tokens) {
     tokens: tokens,
   };
 };
-
 const S3LogParser = {
   parse: (logData) => {
     return logData.trim().split("\n").map(parseLine).map((tokens) => {
       var handler;
-      if (tokens.length == 15) {
+      if (tokens.length === 15) {
         handler = handleELBTokens;
-      } else if (tokens.length == 18) {
+      } else if (tokens.length === 18 || tokens.length === 20) {
         handler = handleALBTokens;
       } else {
         handler = handleUnknownTokens;

--- a/spec/s3-log-parser_spec.js
+++ b/spec/s3-log-parser_spec.js
@@ -31,7 +31,7 @@ describe("S3LogParser", () => {
         request_processing_time: 0.000024,
         backend_processing_time: 0.027673,
         response_processing_time: 0.000021,
-        elb_status_code: "200",
+        http_status: "200",
         backend_status_code: "200",
         received_bytes: 82,
         sent_bytes: 78,
@@ -53,7 +53,7 @@ describe("S3LogParser", () => {
         request_processing_time: 0.000022,
         backend_processing_time: 0.01221,
         response_processing_time: 0.000019,
-        elb_status_code: "200",
+        http_status: "200",
         backend_status_code: "200",
         received_bytes: 82,
         sent_bytes: 81,
@@ -75,7 +75,7 @@ describe("S3LogParser", () => {
         request_processing_time: 0.000021,
         backend_processing_time: 0.01036,
         response_processing_time: 0.000017,
-        elb_status_code: "200",
+        http_status: "200",
         backend_status_code: "200",
         received_bytes: 82,
         sent_bytes: 81,
@@ -91,19 +91,20 @@ describe("S3LogParser", () => {
     describe("when log is from ALB", () => {
       beforeEach(() => {
         logData =
-            'https 2017-04-04T08:15:14.497261Z app/scrivito-backend-beta/9dce4a619ba727ed 35.158.77.50:47048 10.2.110.21:80 0.000 0.020 0.000 200 200 572 608 "GET https://beta-api.scrivito.com:443/tenants/infopark23444378/workspaces/published/changes HTTP/1.1" "scrivito_sdk-1.9.0.rc1" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend-beta/5d440ca6b68ffef6 "Root=1-58e35612-51b49fad053f4b773cd44b0e"\n' +
-            'h2 2017-04-04T08:15:21.873448Z app/scrivito-backend-beta/9dce4a619ba727ed 95.90.245.243:4083 10.2.120.235:80 0.000 0.026 0.000 401 401 2095 486 "PUT https://beta-api.scrivito.com:443/tenants/scrival/perform HTTP/2.0" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend-beta/5d440ca6b68ffef6 "Root=1-58e35619-24c373ba3df691fb0dda673a"\n';
+            'https 2017-04-04T08:15:14.497261Z app/scrivito-backend-beta/9dce4a619ba727ed 35.158.77.50:47048 10.2.110.21:80 0.000 0.020 0.000 200 200 572 608 "GET https://beta-api.scrivito.com:443/tenants/infopark23444378/workspaces/published/changes?p=arams HTTP/1.1" "scrivito_sdk-1.9.0.rc1" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend-beta/5d440ca6b68ffef6 "Root=1-58e35612-51b49fad053f4b773cd44b0e"\n' +
+            'h2 2017-04-04T08:15:21.873448Z app/scrivito-backend-beta/9dce4a619ba727ed 95.90.245.243:4083 10.2.120.235:80 0.000 0.026 0.000 401 401 2095 486 "PUT https://beta-api.scrivito.com:443/tenants/scrival/perform HTTP/2.0" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend-beta/5d440ca6b68ffef6 "Root=1-58e35619-24c373ba3df691fb0dda673a"\n' +
+            'https 2017-10-16T09:45:00.005097Z app/scrivito-backend/7c31ea278f3ef0ae 54.89.89.104:53422 10.2.110.103:80 0.000 0.085 0.000 200 200 505 739 "GET https://api.scrivito.com:443/tenants/rcintegrationtravis094/tasks/7363726976616c2d636d733b7075626c6973682d7263696e746567726174696f6e7472617669733039343a3232474b5a58505957586f675875756c3064616879495547646f4e2b534a5a4d70796965684a315474577467673d HTTP/1.1" "scrivito_sdk-1.11.0.rc1.1186.1858467456" ECDHE-RSA-AES128-GCM-SHA256 TLSv1.2 arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend/2eb6c02f004cbef9 "Root=1-59e47f9b-7823d7963db15e0f06b3864d" "api.scrivito.com" "arn:aws:acm:eu-west-1:115379056088:certificate/02663e4a-8884-470c-a1ce-0df0ac3981cd"\n';
       });
 
       it("creates a loggly event per log line", () => {
         var result = parseLog();
         expect(Array.isArray(result)).toBeTruthy();
-        expect(result.length).toBe(2);
+        expect(result.length).toBe(3);
 
         expect(result[0]).toEqual({
           type: "https",
           timestamp: "2017-04-04T08:15:14.497261Z",
-          elb: "app/scrivito-backend-beta/9dce4a619ba727ed",
+          alb: "app/scrivito-backend-beta/9dce4a619ba727ed",
           client_ip: "35.158.77.50",
           client_port: "47048",
           target: "10.2.110.21",
@@ -111,13 +112,13 @@ describe("S3LogParser", () => {
           request_processing_time: 0,
           target_processing_time: 0.02,
           response_processing_time: 0,
-          elb_status_code: "200",
+          http_status: "200",
           target_status_code: "200",
           received_bytes: 572,
           sent_bytes: 608,
           request_method: "GET",
           request_url: "https://beta-api.scrivito.com:443/tenants/infopark23444378/workspaces/published/changes",
-          request_query_params: "",
+          request_query_params: 'p=arams',
           user_agent: "scrivito_sdk-1.9.0.rc1",
           ssl_cipher: "ECDHE-RSA-AES128-GCM-SHA256",
           ssl_protocol: "TLSv1.2",
@@ -128,7 +129,7 @@ describe("S3LogParser", () => {
         expect(result[1]).toEqual({
           type: "h2",
           timestamp: "2017-04-04T08:15:21.873448Z",
-          elb: "app/scrivito-backend-beta/9dce4a619ba727ed",
+          alb: "app/scrivito-backend-beta/9dce4a619ba727ed",
           client_ip: "95.90.245.243",
           client_port: "4083",
           target: "10.2.120.235",
@@ -136,18 +137,43 @@ describe("S3LogParser", () => {
           request_processing_time: 0,
           target_processing_time: 0.026,
           response_processing_time: 0,
-          elb_status_code: "401",
+          http_status: "401",
           target_status_code: "401",
           received_bytes: 2095,
           sent_bytes: 486,
           request_method: "PUT",
           request_url: "https://beta-api.scrivito.com:443/tenants/scrival/perform",
-          request_query_params: "",
           user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
           ssl_cipher: "ECDHE-RSA-AES128-GCM-SHA256",
           ssl_protocol: "TLSv1.2",
           target_group_arn: "arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend-beta/5d440ca6b68ffef6",
           trace_id: "Root=1-58e35619-24c373ba3df691fb0dda673a",
+        });
+
+        expect(result[2]).toEqual({
+          type: "https",
+          timestamp: "2017-10-16T09:45:00.005097Z",
+          alb: "app/scrivito-backend/7c31ea278f3ef0ae",
+          client_ip: "54.89.89.104",
+          client_port: "53422",
+          target: "10.2.110.103",
+          target_port: "80",
+          request_processing_time: 0,
+          target_processing_time: 0.085,
+          response_processing_time: 0,
+          http_status: "200",
+          target_status_code: "200",
+          received_bytes: 505,
+          sent_bytes: 739,
+          request_method: "GET",
+          request_url: "https://api.scrivito.com:443/tenants/rcintegrationtravis094/tasks/7363726976616c2d636d733b7075626c6973682d7263696e746567726174696f6e7472617669733039343a3232474b5a58505957586f675875756c3064616879495547646f4e2b534a5a4d70796965684a315474577467673d",
+          user_agent: "scrivito_sdk-1.11.0.rc1.1186.1858467456",
+          ssl_cipher: "ECDHE-RSA-AES128-GCM-SHA256",
+          ssl_protocol: "TLSv1.2",
+          target_group_arn: "arn:aws:elasticloadbalancing:eu-west-1:115379056088:targetgroup/scrivito-backend/2eb6c02f004cbef9",
+          trace_id: "Root=1-59e47f9b-7823d7963db15e0f06b3864d",
+          hostname: "api.scrivito.com",
+          certificate_arn: "arn:aws:acm:eu-west-1:115379056088:certificate/02663e4a-8884-470c-a1ce-0df0ac3981cd",
         });
       });
     });


### PR DESCRIPTION
This line contains 20 tokens (instead of 18).

Additional changes:
- renamed key `elb` to `alb` (because that's what it is)
- renamed `?lb_status_code` to `http_status` (RequestLogger's key name)
- omit entries without loggly-able data (e.g. "")
- omit target_port: "-" (AND NOT json.target_port will help ...)
- use more strict comparison operator `===`
- decoupled parsing from result building (alb only)
  - even more clear which token index contributes the value and no token
    index is missed
  - can conditionally omit empty entries